### PR TITLE
Fixed crash when opening settings window

### DIFF
--- a/SpellWork/Forms/FormSettings.Designer.cs
+++ b/SpellWork/Forms/FormSettings.Designer.cs
@@ -29,6 +29,7 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(FormSettings));
+            this.components = new System.ComponentModel.Container();
             this._gbDbSetting = new System.Windows.Forms.GroupBox();
             this._tbBase = new System.Windows.Forms.TextBox();
             this.label5 = new System.Windows.Forms.Label();


### PR DESCRIPTION
This fixes crash which happens when you try to open settings window.

To reproduce this issue, just try to open settings window